### PR TITLE
Showing badges for members - for issue #5

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { UserBadges } from "./UserBadges";
+import { useAccount } from "wagmi";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
@@ -59,6 +60,8 @@ export const HeaderMenuLinks = () => {
 export const Header = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const burgerMenuRef = useRef<HTMLDivElement>(null);
+  const { isConnected } = useAccount();
+
   useOutsideClick(
     burgerMenuRef,
     useCallback(() => setIsDrawerOpen(false), []),
@@ -103,7 +106,7 @@ export const Header = () => {
         </ul>
       </div>
       <div className="navbar-end flex-grow mr-4">
-        <UserBadges />
+        {isConnected && <UserBadges />}
         <RainbowKitCustomConnectButton />
         <FaucetButton />
       </div>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { UserBadges } from "./UserBadges";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
@@ -102,6 +103,7 @@ export const Header = () => {
         </ul>
       </div>
       <div className="navbar-end flex-grow mr-4">
+        <UserBadges />
         <RainbowKitCustomConnectButton />
         <FaucetButton />
       </div>

--- a/packages/nextjs/components/UserBadges.tsx
+++ b/packages/nextjs/components/UserBadges.tsx
@@ -1,5 +1,5 @@
 import { useAccount } from "wagmi";
-import { IdentificationIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
+import { BookmarkSquareIcon, IdentificationIcon, SignalSlashIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 export const UserBadges = () => {
@@ -21,14 +21,17 @@ export const UserBadges = () => {
 
   return (
     <div className="flex gap-2 mr-2">
-      {isBuilderOfBatch11 && (
-        <div className="tooltip tooltip-bottom" data-tip="Is builder of batch 11">
+      {madeCheckin ? (
+        <div className="tooltip tooltip-bottom" data-tip="A builder of batch 11 with confirmed checkin">
+          <BookmarkSquareIcon className="h-6 w-6 text-success" />
+        </div>
+      ) : isBuilderOfBatch11 ? (
+        <div className="tooltip tooltip-bottom" data-tip="A builder of batch 11">
           <IdentificationIcon className="h-6 w-6 text-success" />
         </div>
-      )}
-      {madeCheckin && (
-        <div className="tooltip tooltip-bottom" data-tip="Made checkin">
-          <PuzzlePieceIcon className="h-6 w-6 text-success" />
+      ) : (
+        <div className="tooltip tooltip-bottom" data-tip="Not a builder of batch 11">
+          <SignalSlashIcon className="h-6 w-6 opacity-50" />
         </div>
       )}
     </div>

--- a/packages/nextjs/components/UserBadges.tsx
+++ b/packages/nextjs/components/UserBadges.tsx
@@ -23,15 +23,15 @@ export const UserBadges = () => {
     <div className="flex gap-2 mr-2">
       {madeCheckin ? (
         <div className="tooltip tooltip-bottom" data-tip="A builder of batch 11 with confirmed checkin">
-          <BookmarkSquareIcon className="h-6 w-6 text-success" />
+          <BookmarkSquareIcon className="h-7 w-7 p-1 bg-secondary-content text-secondary rounded-full" />
         </div>
       ) : isBuilderOfBatch11 ? (
         <div className="tooltip tooltip-bottom" data-tip="A builder of batch 11">
-          <IdentificationIcon className="h-6 w-6 text-success" />
+          <IdentificationIcon className="h-7 w-7 p-1 bg-secondary-content text-secondary rounded-full" />
         </div>
       ) : (
         <div className="tooltip tooltip-bottom" data-tip="Not a builder of batch 11">
-          <SignalSlashIcon className="h-6 w-6 opacity-50" />
+          <SignalSlashIcon className="h-7 w-7 p-1 opacity-50" />
         </div>
       )}
     </div>

--- a/packages/nextjs/components/UserBadges.tsx
+++ b/packages/nextjs/components/UserBadges.tsx
@@ -1,0 +1,36 @@
+import { useAccount } from "wagmi";
+import { IdentificationIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+
+export const UserBadges = () => {
+  const { address } = useAccount();
+
+  const { data: isBuilderOfBatch11 } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+
+  const { data: contractAddress } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
+  });
+
+  const madeCheckin = contractAddress && contractAddress !== "0x0000000000000000000000000000000000000000";
+
+  return (
+    <div className="flex gap-2 mr-2">
+      {isBuilderOfBatch11 && (
+        <div className="tooltip tooltip-bottom" data-tip="Is builder of batch 11">
+          <IdentificationIcon className="h-6 w-6 text-success" />
+        </div>
+      )}
+      {madeCheckin && (
+        <div className="tooltip tooltip-bottom" data-tip="Made checkin">
+          <PuzzlePieceIcon className="h-6 w-6 text-success" />
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Showing badges at the header for when the user is a Batch11 builder and another badge for when the user completed the checkin.
![image](https://github.com/user-attachments/assets/136f78a5-b7aa-49a4-9518-7b961ea47a61)

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Closes #5

Your ENS/address:
0x2Bc096A12C5b37F035180aDeF70EB2B88351e5B8