### PR TITLE
feat: enhance homepage and add builders grid

### DIFF
--- a/packages/nextjs/app/api/builders/route.ts
+++ b/packages/nextjs/app/api/builders/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { readdir } from "fs/promises";
+import path from "path";
+
+export async function GET() {
+  const buildersPath = path.join(process.cwd(), "app/builders");
+
+  try {
+    const directories = await readdir(buildersPath, { withFileTypes: true });
+    const addresses = directories
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name)
+      .filter(name => name.startsWith("0x"));
+
+    return NextResponse.json(addresses);
+  } catch {
+    return NextResponse.json([], { status: 500 });
+  }
+}

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import BuildersGrid from "~~/components/batch/BuildersGrid";
 
 const Home: NextPage = () => {
   return (
@@ -44,6 +45,8 @@ const Home: NextPage = () => {
             </div>
           </div>
         </div>
+        {/* Builders Grid */}
+        <BuildersGrid />
       </div>
     </>
   );

--- a/packages/nextjs/components/batch/BuildersGrid.tsx
+++ b/packages/nextjs/components/batch/BuildersGrid.tsx
@@ -32,24 +32,24 @@ const BuildersGrid = () => {
   const buildersWithoutProfile = (events ?? [])
     .map(event => event.args.builder)
     .filter(address => address && !profileBuilders.includes(address));
-  console.log(buildersWithoutProfile);
 
   return (
     <div className="w-full px-6 py-8">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {profileBuilders.map((address, idx) => (
-          <Link
+          <div
             key={`${address}-${idx}`}
-            href={`/builders/${address}`}
             className="bg-base-100 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-200 border border-base-200"
           >
             <div className="flex flex-col gap-2">
               <Address address={address} size="lg" />
               <div className="flex justify-between items-center">
-                <span className="text-sm font-semibold hover:underline">View Profile →</span>
+                <Link href={`/builders/${address}`} className="text-sm font-semibold hover:underline">
+                  View Profile →
+                </Link>
               </div>
             </div>
-          </Link>
+          </div>
         ))}
         {buildersWithoutProfile.map((address, idx) => (
           <div

--- a/packages/nextjs/components/batch/BuildersGrid.tsx
+++ b/packages/nextjs/components/batch/BuildersGrid.tsx
@@ -1,15 +1,9 @@
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { Address } from "~~/components/scaffold-eth";
-import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 
 const BuildersGrid = () => {
-  // Get total number of checked-in builders from contract
-  const { data: checkedInCount, isLoading: countLoading } = useScaffoldReadContract({
-    contractName: "BatchRegistry",
-    functionName: "checkedInCounter",
-  });
-
   // Get builder profiles from filesystem
   const { data: profileBuilders = [], isLoading: profilesLoading } = useQuery<string[]>({
     queryKey: ["builders-profiles"],
@@ -20,7 +14,14 @@ const BuildersGrid = () => {
     },
   });
 
-  if (countLoading || profilesLoading) {
+  // Get checked-in builders from contract events
+  const { data: events, isLoading: eventsLoading } = useScaffoldEventHistory({
+    contractName: "BatchRegistry",
+    eventName: "CheckedIn",
+    fromBlock: 127324219n,
+  });
+
+  if (profilesLoading || eventsLoading) {
     return (
       <div className="w-full px-6 py-8 text-center">
         <span className="loading loading-spinner loading-lg text-primary"></span>
@@ -28,13 +29,13 @@ const BuildersGrid = () => {
     );
   }
 
+  const buildersWithoutProfile = (events ?? [])
+    .map(event => event.args.builder)
+    .filter(address => address && !profileBuilders.includes(address));
+  console.log(buildersWithoutProfile);
+
   return (
     <div className="w-full px-6 py-8">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold mb-2">Batch Members ({checkedInCount?.toString() || "0"} checked in)</h2>
-        <p className="text-sm text-base-content/70">Showing builders who have created their profiles</p>
-      </div>
-
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {profileBuilders.map((address, idx) => (
           <Link
@@ -46,12 +47,22 @@ const BuildersGrid = () => {
               <Address address={address} size="lg" />
               <div className="flex justify-between items-center">
                 <span className="text-sm font-semibold hover:underline">View Profile →</span>
-                {checkedInCount && checkedInCount > 0 && (
-                  <span className="text-xs bg-primary/10 px-2 py-1 rounded-full">Checked In</span>
-                )}
               </div>
             </div>
           </Link>
+        ))}
+        {buildersWithoutProfile.map((address, idx) => (
+          <div
+            key={`${address}-${idx}`}
+            className="bg-base-100 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-200 border border-base-200"
+          >
+            <div className="flex flex-col gap-2">
+              <Address address={address} size="lg" />
+              <div className="flex justify-between items-center">
+                <span className="text-sm font-semibold text-primary">No Profile</span>
+              </div>
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/packages/nextjs/components/batch/BuildersGrid.tsx
+++ b/packages/nextjs/components/batch/BuildersGrid.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Address } from "~~/components/scaffold-eth";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+
+const BuildersGrid = () => {
+  // Get total number of checked-in builders from contract
+  const { data: checkedInCount, isLoading: countLoading } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
+  // Get builder profiles from filesystem
+  const { data: profileBuilders = [], isLoading: profilesLoading } = useQuery<string[]>({
+    queryKey: ["builders-profiles"],
+    queryFn: async () => {
+      const response = await fetch("/api/builders");
+      if (!response.ok) throw new Error("Failed to fetch builders");
+      return response.json();
+    },
+  });
+
+  if (countLoading || profilesLoading) {
+    return (
+      <div className="w-full px-6 py-8 text-center">
+        <span className="loading loading-spinner loading-lg text-primary"></span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full px-6 py-8">
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold mb-2">Batch Members ({checkedInCount?.toString() || "0"} checked in)</h2>
+        <p className="text-sm text-base-content/70">Showing builders who have created their profiles</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {profileBuilders.map((address, idx) => (
+          <Link
+            key={`${address}-${idx}`}
+            href={`/builders/${address}`}
+            className="bg-base-100 rounded-xl p-6 shadow-lg hover:shadow-xl transition-all duration-200 border border-base-200"
+          >
+            <div className="flex flex-col gap-2">
+              <Address address={address} size="lg" />
+              <div className="flex justify-between items-center">
+                <span className="text-sm font-semibold hover:underline">View Profile →</span>
+                {checkedInCount && checkedInCount > 0 && (
+                  <span className="text-xs bg-primary/10 px-2 py-1 rounded-full">Checked In</span>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BuildersGrid;


### PR DESCRIPTION
# Enhanced Homepage and Builders Grid

## Changes Made
- Added BuildersGrid component showing registered builders
- Created API route to fetch builder addresses from filesystem
- Connected grid to personal builder pages
- Enhanced homepage dark mode visibility
- Updated styling for better UX

## Implementation Details
- Scans filesystem for builder pages in `/builders` directory
- Displays builder profiles in responsive grid layout
- Maintains consistent styling with existing components

[Add screenshots of homepage and grid in light/dark modes]
### Screenshot for the Checked Builders Count:
![image](https://github.com/user-attachments/assets/38b18660-eb16-42a3-be1e-7f05f961049b)

### Screenshot for the number of registered builders page:
![image](https://github.com/user-attachments/assets/b17b65d5-f9ed-40b3-8cf0-f606d47c9522)

## Additional Information
- Still trying to fix some console issues

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #4 _

Your ENS/address: 0x5cc8Be96B1C9A68F57a73b5bEa60cF5D890055A1
